### PR TITLE
Add support for UNIX domain sockets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-macro"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,6 +520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "pin-project-lite",
@@ -719,6 +731,19 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fafdf7b2b2de7c9784f76e02c0935e65a8117ec3b768644379983ab333ac98c"
+dependencies = [
+ "futures-util",
+ "hex",
+ "hyper",
+ "pin-project",
+ "tokio",
 ]
 
 [[package]]
@@ -951,6 +976,8 @@ dependencies = [
  "deb-version",
  "hex",
  "html-escape",
+ "hyper",
+ "hyperlocal",
  "indexmap",
  "itertools",
  "mime_guess",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ itertools = "0.10"
 hex = "0.4"
 proc-macro-regex = "^1"
 structopt = "0.3"
+hyper = "0.14"
+hyperlocal = "0.8"
 
 [profile.dev.package.askama_derive]
 opt-level = 3


### PR DESCRIPTION
Use `listen = "unix:/path/to/socket.sock"` to let packages-site-rs listen on a UNIX domain socket.