### PR TITLE
Make strip_prefix infallible

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,6 @@
 use crate::db::Db;
 use crate::sql::SQL_GET_REPO_COUNT;
 use crate::sql::SQL_GET_TREES;
-use anyhow::Context;
 use askama::Template;
 use axum::async_trait;
 use axum::extract::FromRequestParts;
@@ -248,9 +247,8 @@ impl QueryExtractor {
     }
 }
 
-pub fn strip_prefix(s: &str) -> Result<&str> {
-    Ok(s.strip_prefix('/')
-        .with_context(|| format!("falied to strip prefix \"{}\"", s))?)
+pub fn strip_prefix(s: &str) -> &str {
+    s.strip_prefix('/').unwrap_or(s)
 }
 
 pub async fn get_repo(repo: &str, db: &Ext) -> Result<Repo> {

--- a/src/views/misc.rs
+++ b/src/views/misc.rs
@@ -120,7 +120,7 @@ pub async fn cleanmirror(CleanMirror { repo }: CleanMirror, q: Query, db: Ext) -
         .get_reason()
         .as_ref()
         .map(|r| r.split(',').map(|x| x.to_string()).collect());
-    let repo = strip_prefix(&repo)?;
+    let repo = strip_prefix(&repo);
 
     #[derive(Debug, FromRow, Serialize)]
     struct Deb {

--- a/src/views/qa.rs
+++ b/src/views/qa.rs
@@ -279,7 +279,7 @@ async fn qa_code_common(code: String, repo: Option<String>, q: Query, db: Ext) -
     }
 
     let repo = if let Some(repo) = repo {
-        Some(strip_prefix(&repo)?.to_string())
+        Some(strip_prefix(&repo).to_string())
     } else {
         None
     };

--- a/src/views/repo.rs
+++ b/src/views/repo.rs
@@ -42,7 +42,7 @@ pub async fn repo(RouteRepo { repo }: RouteRepo, q: Query, db: Ext) -> Result<im
         packages: &'a Vec<PackageTemplate>,
     }
 
-    let repo = strip_prefix(&repo)?;
+    let repo = strip_prefix(&repo);
     get_repo(repo, &db).await?;
 
     let (packages, page): (Vec<Package>, _) = query_as(SQL_GET_PACKAGE_REPO)
@@ -109,7 +109,7 @@ pub async fn lagging(Lagging { repo }: Lagging, q: Query, db: Ext) -> Result<imp
         packages: &'a Vec<Package>,
     }
 
-    let repo = strip_prefix(&repo)?;
+    let repo = strip_prefix(&repo);
     let architecture = get_repo(repo, &db).await?.architecture;
 
     let (ref packages, page): (Vec<Package>, _) = query_as(SQL_GET_PACKAGE_LAGGING)
@@ -158,7 +158,7 @@ pub async fn missing(Missing { repo }: Missing, q: Query, db: Ext) -> Result<imp
         packages: &'a Vec<Package>,
     }
 
-    let repo = strip_prefix(&repo)?;
+    let repo = strip_prefix(&repo);
     let repo = get_repo(repo, &db).await?;
 
     let (ref packages, page): (Vec<Package>, _) = query_as(SQL_GET_PACKAGE_MISSING)
@@ -205,7 +205,7 @@ pub async fn ghost(Ghost { repo }: Ghost, q: Query, db: Ext) -> Result<impl Into
         packages: &'a Vec<Package>,
     }
 
-    let repo = strip_prefix(&repo)?;
+    let repo = strip_prefix(&repo);
     get_repo(repo, &db).await?;
 
     let (ref packages, page): (Vec<Package>, _) = query_as(SQL_GET_PACKAGE_GHOST)


### PR DESCRIPTION
Fixes the 'failed to strip prefix "xxx/xxx"' error in Repo/QA pages.

The '/' prefix isn't always present in repo names.