### PR TITLE
fix: mobile home page searchinput layout overflow error

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -286,6 +286,7 @@ li {
   border-width: 0 0 1.5px;
   border-style: solid;
   outline: 0;
+  box-sizing: border-box;
 }
 
 #searchinput:focus {


### PR DESCRIPTION
<img width="901" alt="image" src="https://github.com/user-attachments/assets/99cb3aa1-8f21-46ce-9e23-305a94c10a14" />

## Fix

Add `box-sizing: border-box;` in `#searchinput`

```diff
#searchinput {
  outline: 0;
+ box-sizing: border-box;
}
```

### error version

```
firefox:
"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:139.0) Gecko/20100101 Firefox/139.0" 

chrome:
'Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1'
```
