### PR TITLE
feat: drop error checks and status display

### DIFF
--- a/src/filters.rs
+++ b/src/filters.rs
@@ -68,7 +68,6 @@ pub fn fmt_ver_compare(ver_compare: &i32) -> ::askama::Result<&'static str> {
 pub fn fmt_pkg_status(status: &i32) -> ::askama::Result<&'static str> {
     Ok(match *status {
         0 => "normal",
-        1 => "error",
         2 => "testing",
         _ => "unknown",
     })

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -10,20 +10,6 @@ WHERE
     package = $1
 ";
 
-pub const SQL_GET_PACKAGE_ERRORS: &str = "
-SELECT
-    message,
-    path,
-    tree,
-    branch,
-    line,
-    col
-FROM
-    package_errors
-WHERE
-    package = $1
-";
-
 pub const SQL_GET_PACKAGE_CHANGELOG: &str = "
 SELECT
     package,
@@ -325,11 +311,8 @@ SELECT DISTINCT ON (commit_time, name)
         -2
     ) ver_compare,
     CASE
-        WHEN error.package IS NOT NULL THEN 1
-        ELSE CASE
-            WHEN testing.package IS NOT NULL THEN 2
-            ELSE 0
-        END
+        WHEN testing.package IS NOT NULL THEN 2
+        ELSE 0
     END AS status
 FROM
     v_packages
@@ -340,12 +323,6 @@ FROM
         FROM
             package_testing
     ) testing ON testing.package = v_packages.name
-    LEFT JOIN (
-        SELECT
-            DISTINCT package
-        FROM
-            package_errors
-    ) error ON error.package = v_packages.name
 WHERE
     full_version IS NOT NULL and dpkg_version IS NOT NULL
 ORDER BY
@@ -374,11 +351,8 @@ SELECT
         -2
     ) ver_compare,
     CASE
-        WHEN error.package IS NOT NULL THEN 1
-        ELSE CASE
-            WHEN testing.package IS NOT NULL THEN 2
-            ELSE 0
-        END
+        WHEN testing.package IS NOT NULL THEN 2
+        ELSE 0
     END AS status
 FROM
     v_packages
@@ -389,12 +363,6 @@ FROM
         FROM
             package_testing
     ) testing ON testing.package = v_packages.name
-    LEFT JOIN (
-        SELECT
-            DISTINCT package
-        FROM
-            package_errors
-    ) error ON error.package = v_packages.name
 WHERE
     full_version IS NOT null
 ORDER BY
@@ -411,11 +379,8 @@ SELECT
     dpkg.dpkg_version dpkg_version,
     p.description description,
     CASE
-        WHEN error.package IS NOT NULL THEN 1
-        ELSE CASE
-            WHEN testing.package IS NOT NULL THEN 2
-            ELSE 0
-        END
+        WHEN testing.package IS NOT NULL THEN 2
+        ELSE 0
     END AS status
 FROM
     v_packages p
@@ -425,12 +390,6 @@ FROM
         FROM
             package_testing
     ) testing ON testing.package = p.name
-    LEFT JOIN (
-        SELECT
-            DISTINCT package
-        FROM
-            package_errors
-    ) error ON error.package = p.name
     LEFT JOIN package_spec spabhost ON spabhost.package = p.name
     AND spabhost.key = 'ABHOST'
     LEFT JOIN v_dpkg_packages_new dpkg ON dpkg.package = p.name

--- a/src/views/package.rs
+++ b/src/views/package.rs
@@ -78,16 +78,6 @@ pub async fn packages(RoutePackage { name }: RoutePackage, q: Query, db: Ext) ->
         fullver: String,
     }
 
-    #[derive(FromRow, Serialize, Debug)]
-    struct PackageError {
-        message: String,
-        path: String,
-        tree: String,
-        branch: String,
-        col: Option<i32>,
-        line: Option<i32>,
-    }
-
     #[derive(FromRow)]
     struct PackageTesting {
         pub full_version: String,
@@ -108,7 +98,6 @@ pub async fn packages(RoutePackage { name }: RoutePackage, q: Query, db: Ext) ->
         section: &'a String,
         dependencies: Vec<Dependency>,
         library_dependencies: Vec<String>,
-        errors: Vec<PackageError>,
         hasrevdep: bool,
         srctype: String,
         srcurl_base: String,
@@ -137,9 +126,6 @@ pub async fn packages(RoutePackage { name }: RoutePackage, q: Query, db: Ext) ->
     } else {
         not_found!("Package \"{name}\" not found");
     };
-
-    // collect package error messages
-    let errors: Vec<PackageError> = query_as(SQL_GET_PACKAGE_ERRORS).bind(&name).fetch_all(&db.meta).await?;
 
     // Generate version matrix
 
@@ -369,9 +355,6 @@ pub async fn packages(RoutePackage { name }: RoutePackage, q: Query, db: Ext) ->
         // dependencies
         dependencies: Dependency::parse_db_dependencies(&pkg.dependency),
         library_dependencies: library_deps.into_iter().map(|dep| dep.0).collect(),
-
-        // errors
-        errors,
 
         // dpkg_matrix
         versions,

--- a/static/style.css
+++ b/static/style.css
@@ -419,10 +419,6 @@ li {
   background-color: hsl(185, 100%, 77%);
 }
 
-.pkg-status-error {
-  background-color: #E87A90;
-}
-
 .legend {
   border: none;
 }

--- a/templates/legend.inc.html
+++ b/templates/legend.inc.html
@@ -6,7 +6,6 @@
       <p class="dpkg-ver-same">Package up to date</p>
       <p class="pkg-status-testing">Package in testing branch</p>
       <p class="dpkg-ver-old">Package older than source or missing</p>
-      <p class="pkg-status-error">Source file contains error</p>
       <p class="dpkg-ver-deprecated">Source has removed the package</p>
     </td>
   </tr>

--- a/templates/package.html
+++ b/templates/package.html
@@ -49,19 +49,6 @@
 </p>
 {%- endif %}
 
-{% if !errors.is_empty() -%}
-<p><b class="pkg-field">Errors</b>:
-
-{% for PackageError{message, tree, branch, path, line, col} in errors %}
-<p>
-<a href="{{ "https://github.com/AOSC-Dev/{}/tree/{}/{}"|format(tree,branch,path) }}{% match line %}{% when Some with (line) %}{{ "#L{}"|format(line) }}{% when None %}{% endmatch %}  ">{{path}}</a>:  {{ message }} 
-</p>
-
-{% endfor %}
-
-
-{%- endif %}
-
 </section>
 
 


### PR DESCRIPTION
It seems pointless to display scripting and QA errors on an end-user- facing site, especially when some of the more expensive checks (ELF and file collisions, etc.) were never enabled.

Let's keep these errors for maintainers - Autobuild does a good enough job catching them and even GitHub Actions sounds like a better place for these checks.